### PR TITLE
Feature/login jwt

### DIFF
--- a/src/main/java/com/football/KickBoard/application/member/MemberService.java
+++ b/src/main/java/com/football/KickBoard/application/member/MemberService.java
@@ -1,0 +1,10 @@
+package com.football.KickBoard.application.member;
+
+import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MemberService {
+  void signup(MemberSignupRequestDto requestDto);
+
+}

--- a/src/main/java/com/football/KickBoard/application/member/MemberService.java
+++ b/src/main/java/com/football/KickBoard/application/member/MemberService.java
@@ -1,10 +1,16 @@
 package com.football.KickBoard.application.member;
 
+import com.football.KickBoard.web.member.dto.MemberLoginRequestDto;
+import com.football.KickBoard.web.member.dto.MemberLoginResponseDto;
 import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
   void signup(MemberSignupRequestDto requestDto);
 
+  MemberLoginResponseDto login(MemberLoginRequestDto requestDto);
+
+  String getCurrentUserId();
 }

--- a/src/main/java/com/football/KickBoard/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/football/KickBoard/application/member/MemberServiceImpl.java
@@ -1,9 +1,13 @@
 package com.football.KickBoard.application.member;
 
+import com.football.KickBoard.common.security.JwtTokenProvider;
 import com.football.KickBoard.domain.member.Member;
 import com.football.KickBoard.domain.member.MemberRepository;
+import com.football.KickBoard.web.member.dto.MemberLoginRequestDto;
+import com.football.KickBoard.web.member.dto.MemberLoginResponseDto;
 import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +17,36 @@ public class MemberServiceImpl implements MemberService{
 
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
+  private final JwtTokenProvider jwtTokenProvider;
 
+  @Override
+  public String getCurrentUserId(){
+    return (String) SecurityContextHolder.getContext()
+        .getAuthentication()
+        .getPrincipal();
+  }
+
+
+  @Override
+  public MemberLoginResponseDto login(MemberLoginRequestDto requestDto){
+    Member member = memberRepository.findByuserId(requestDto.getUserId())
+        .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 아이디 입니다."));
+//비밀번호는 위와 같이 findByuserId처럼 DB에서 직접찾는형식 x개인정보
+  if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword() )){
+    throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+  }
+  //JWT토큰 생성
+    String token = jwtTokenProvider.generateToken(member.getUserId());
+
+    return MemberLoginResponseDto.builder()
+        .userId(member.getUserId())
+        .token(token)
+        .build();
+
+  }
+
+
+  //회원가입 내용
   @Override
   public void signup(MemberSignupRequestDto requestDto) {
 

--- a/src/main/java/com/football/KickBoard/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/football/KickBoard/application/member/MemberServiceImpl.java
@@ -1,0 +1,42 @@
+package com.football.KickBoard.application.member;
+
+import com.football.KickBoard.domain.member.Member;
+import com.football.KickBoard.domain.member.MemberRepository;
+import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService{
+
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public void signup(MemberSignupRequestDto requestDto) {
+
+    //중복검사
+    memberRepository.findByuserId(requestDto.getUserId()).ifPresent(member ->{
+      throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+    });
+    //비밀번호 암호화
+    String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+  //멤버 엔티티 생성
+    Member member = Member.builder()
+        .userId(requestDto.getUserId())
+        .password(encodedPassword)
+        .email(requestDto.getEmail())
+        .nickname(requestDto.getNickname())
+        .favoriteTeam(requestDto.getFavoriteTeam())
+        .build();
+
+    // 저장
+    memberRepository.save(member);
+  }
+
+}
+
+

--- a/src/main/java/com/football/KickBoard/common/config/SecurityConfig.java
+++ b/src/main/java/com/football/KickBoard/common/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.football.KickBoard.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public PasswordEncoder passwordEncoder(){
+    return new BCryptPasswordEncoder();
+  }
+//나중에 시큐리티 인증/인가 설정도 여기에 추가
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+    http
+        .csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/members/signup").permitAll()// 회원가입 경로 허용
+            .anyRequest().authenticated())// 그 외 모든 요청은 인증 필요
+        // 기본 폼 로그인 비활성화 (자동 /login 리디렉션 방지)
+        .formLogin(form ->form.disable())
+        // 기본 HTTP Basic 인증 비활성화 (포스트맨 401 에러 방지)
+        .httpBasic(basic -> basic.disable());
+    return http.build();
+  }
+}

--- a/src/main/java/com/football/KickBoard/common/config/SecurityConfig.java
+++ b/src/main/java/com/football/KickBoard/common/config/SecurityConfig.java
@@ -1,31 +1,46 @@
 package com.football.KickBoard.common.config;
 
+import com.football.KickBoard.common.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
   public PasswordEncoder passwordEncoder(){
     return new BCryptPasswordEncoder();
   }
-//나중에 시큐리티 인증/인가 설정도 여기에 추가
+// 시큐리티 인증/인가 설정
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
     http
         .csrf(csrf -> csrf.disable())
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))//세션 미사용
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/members/signup").permitAll()// 회원가입 경로 허용
+            .requestMatchers("/members/signup","/members/login").permitAll()// 회원가입 경로 허용
             .anyRequest().authenticated())// 그 외 모든 요청은 인증 필요
         // 기본 폼 로그인 비활성화 (자동 /login 리디렉션 방지)
         .formLogin(form ->form.disable())
         // 기본 HTTP Basic 인증 비활성화 (포스트맨 401 에러 방지)
-        .httpBasic(basic -> basic.disable());
+        .httpBasic(basic -> basic.disable())
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
     return http.build();
+  }
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration config)throws Exception{
+    return config.getAuthenticationManager();
   }
 }

--- a/src/main/java/com/football/KickBoard/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/football/KickBoard/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.football.KickBoard.common.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  //유효성 검증 실패 시 예외 처리
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String ,String >> handleValidationExceptions(
+      MethodArgumentNotValidException ex){
+    Map<String, String> errors = new HashMap<>();
+    BindingResult bindingResult = ex.getBindingResult();
+
+    bindingResult.getAllErrors().forEach(error ->{
+      String filedName = ((FieldError) error).getField();
+      String errorMessage = error.getDefaultMessage();
+      errors.put(filedName,errorMessage);
+    });
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+  }
+  // IllegalArgumentException 예외 처리 (이미 사용 중인 아이디 등)
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
+      IllegalArgumentException ex) {
+
+    Map<String, String> error = new HashMap<>();
+    error.put("message", ex.getMessage());
+
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+  }
+
+  // 그 외 모든 예외 처리
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Map<String, String>> handleAllExceptions(Exception ex) {
+    Map<String, String> error = new HashMap<>();
+    error.put("message", "서버 내부 오류가 발생했습니다.");
+    error.put("detail", ex.getMessage());
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+  }
+
+
+}

--- a/src/main/java/com/football/KickBoard/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/football/KickBoard/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.football.KickBoard.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+  //모든 요청 가로채서 JWT 검증
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain
+  ) throws ServletException, IOException{
+
+      String token = jwtTokenProvider.resolveToken(request);
+
+    //토큰이 존재하고 유효하면 토큰에서 userId 추출
+    if(token !=  null && jwtTokenProvider.validateToken(token)){
+      String userId = jwtTokenProvider.getUserIdFromToken(token);
+
+      JwtAuthenticationToken authentication =
+          new JwtAuthenticationToken(userId, null, null);
+    //JwtAuthenticationToken의 authorities 부분은 권한 정보를 의미
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+  filterChain.doFilter(request,response);
+  }
+
+}

--- a/src/main/java/com/football/KickBoard/common/security/JwtAuthenticationToken.java
+++ b/src/main/java/com/football/KickBoard/common/security/JwtAuthenticationToken.java
@@ -1,0 +1,34 @@
+package com.football.KickBoard.common.security;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+  private final Object principal;
+  private Object credentials;
+
+  public JwtAuthenticationToken(Object principal,Object credentials){
+    super(null);
+    this.principal = principal;
+    this.credentials = credentials;
+    setAuthenticated(false);
+  }
+  public JwtAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities){
+  super(authorities);
+  this.principal = principal;
+  this.credentials = credentials;
+  setAuthenticated(true);
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return principal;
+  }
+
+  @Override
+  public Object getCredentials() {
+    return credentials;
+  }
+}

--- a/src/main/java/com/football/KickBoard/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/football/KickBoard/common/security/JwtTokenProvider.java
@@ -1,0 +1,83 @@
+package com.football.KickBoard.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  //TODO 로그아웃 처리 (JWT 블랙리스트 or 클라이언트 삭제),Refresh Token 도입 (토큰 재발급)
+
+
+  //SECRET_KEY 하드코딩 실무에서는 시스템 환경변수 등에 키를 저장
+  @Value("${jwt.secret}")
+  private  String SECRET_KEY;
+  private final long EXPIRATION_TIME = 1000 * 60 * 60;//토큰 생성 후 유지 시간
+  private  Key key;
+
+  @PostConstruct
+  public void init() {
+    this.key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+  }
+  public String resolveToken(HttpServletRequest request){
+    String bearerToken = request.getHeader("Authorization");
+    if (bearerToken != null && bearerToken.startsWith("Bearer ")){
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+
+  //토큰 유효성 검증
+  public boolean validateToken(String token){
+    try {
+      Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token);
+      return true;
+    }catch (ExpiredJwtException e){
+      System.out.println("토큰 만료: " + e.getMessage());
+    }catch (UnsupportedJwtException e){
+      System.out.println("지원하지 않는 JWT; " + e.getMessage());
+    }catch (MalformedJwtException e){
+      System.out.println("잘못된 JWT 형식: " + e.getMessage());
+    }catch (SignatureException e){
+      System.out.println("잘못된 서명:" + e.getMessage());
+    }catch (IllegalArgumentException e){
+      System.out.println("JWT claims가 비어있음: " + e.getMessage());
+    }
+    return false;
+  }
+  public String getUserIdFromToken(String token){
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    return claims.getSubject();
+  }
+
+  public String generateToken(String userId){
+    return Jwts.builder()
+        .setSubject(userId)
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+        .signWith(key)
+        .compact();
+
+  }
+
+}

--- a/src/main/java/com/football/KickBoard/domain/member/Member.java
+++ b/src/main/java/com/football/KickBoard/domain/member/Member.java
@@ -1,0 +1,44 @@
+package com.football.KickBoard.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Member {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;//내부 식별자(Pk)
+
+  @Column(name = "userid",nullable = false,unique = true)
+  private String userId; //사용자 ID
+  @Column(nullable = false)
+  private String password;
+  @Column(nullable = false)
+  private String email;
+  @Column(nullable = false)
+  private String  nickname;
+
+  private String  phoneNumber;
+  private LocalDate birthDate;
+  @Column(nullable = false)
+  private String favoriteTeam;
+
+
+
+
+
+}

--- a/src/main/java/com/football/KickBoard/domain/member/MemberRepository.java
+++ b/src/main/java/com/football/KickBoard/domain/member/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.football.KickBoard.domain.member;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member,Long> {
+  Optional<Member> findByuserId(String userId);
+}

--- a/src/main/java/com/football/KickBoard/web/member/MemberController.java
+++ b/src/main/java/com/football/KickBoard/web/member/MemberController.java
@@ -1,11 +1,16 @@
 package com.football.KickBoard.web.member;
 
 import com.football.KickBoard.application.member.MemberService;
+import com.football.KickBoard.application.member.MemberServiceImpl;
+import com.football.KickBoard.web.member.dto.MemberLoginRequestDto;
+import com.football.KickBoard.web.member.dto.MemberLoginResponseDto;
 import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,12 +20,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
+
   private final MemberService memberService;
 
+  //토큰 아이디 추출 테스트용 getMapping
+  @GetMapping("/me")
+  public ResponseEntity<String> getCurrentUser() {
+    String userId = memberService.getCurrentUserId();
+    return ResponseEntity.ok("현재 로그인한 사용자: " + userId);
+  }
+
+
   @PostMapping("/signup")
-  public ResponseEntity<String> signup(@Valid @RequestBody MemberSignupRequestDto requestDto){
+  public ResponseEntity<String> signup(@Valid @RequestBody MemberSignupRequestDto requestDto) {
     memberService.signup(requestDto);
     return ResponseEntity.ok("회원가입 완료");// 재 풀 리퀘스트 위한 주석 추가.
   }
 
+  @PostMapping("/login")
+  public ResponseEntity<MemberLoginResponseDto> login(@Valid @RequestBody MemberLoginRequestDto requestDto) {
+    MemberLoginResponseDto response = memberService.login(requestDto);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/football/KickBoard/web/member/MemberController.java
+++ b/src/main/java/com/football/KickBoard/web/member/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
   @PostMapping("/signup")
   public ResponseEntity<String> signup(@Valid @RequestBody MemberSignupRequestDto requestDto){
     memberService.signup(requestDto);
-    return ResponseEntity.ok("회원가입 완료");//회원가입 완료메시지 출력
+    return ResponseEntity.ok("회원가입 완료");// 재 풀 리퀘스트 위한 주석 추가.
   }
 
 }

--- a/src/main/java/com/football/KickBoard/web/member/MemberController.java
+++ b/src/main/java/com/football/KickBoard/web/member/MemberController.java
@@ -1,0 +1,26 @@
+package com.football.KickBoard.web.member;
+
+import com.football.KickBoard.application.member.MemberService;
+import com.football.KickBoard.web.member.dto.MemberSignupRequestDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+  private final MemberService memberService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<String> signup(@Valid @RequestBody MemberSignupRequestDto requestDto){
+    memberService.signup(requestDto);
+    return ResponseEntity.ok("회원가입 완료");
+  }
+
+}

--- a/src/main/java/com/football/KickBoard/web/member/MemberController.java
+++ b/src/main/java/com/football/KickBoard/web/member/MemberController.java
@@ -20,7 +20,7 @@ public class MemberController {
   @PostMapping("/signup")
   public ResponseEntity<String> signup(@Valid @RequestBody MemberSignupRequestDto requestDto){
     memberService.signup(requestDto);
-    return ResponseEntity.ok("회원가입 완료");
+    return ResponseEntity.ok("회원가입 완료");//회원가입 완료메시지 출력
   }
 
 }

--- a/src/main/java/com/football/KickBoard/web/member/dto/MemberJoinRequest.java
+++ b/src/main/java/com/football/KickBoard/web/member/dto/MemberJoinRequest.java
@@ -1,0 +1,13 @@
+package com.football.KickBoard.web.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberJoinRequest {
+  private String email;
+  private String password;
+  private String name;
+
+}

--- a/src/main/java/com/football/KickBoard/web/member/dto/MemberLoginRequestDto.java
+++ b/src/main/java/com/football/KickBoard/web/member/dto/MemberLoginRequestDto.java
@@ -1,0 +1,13 @@
+package com.football.KickBoard.web.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class MemberLoginRequestDto {
+  @NotBlank
+  private String userId;
+  @NotBlank
+  private String password;
+
+}

--- a/src/main/java/com/football/KickBoard/web/member/dto/MemberLoginResponseDto.java
+++ b/src/main/java/com/football/KickBoard/web/member/dto/MemberLoginResponseDto.java
@@ -1,0 +1,15 @@
+package com.football.KickBoard.web.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberLoginResponseDto {
+  private String userId;
+  private String token;
+}

--- a/src/main/java/com/football/KickBoard/web/member/dto/MemberSignupRequestDto.java
+++ b/src/main/java/com/football/KickBoard/web/member/dto/MemberSignupRequestDto.java
@@ -1,0 +1,26 @@
+package com.football.KickBoard.web.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class  MemberSignupRequestDto{
+
+  @NotBlank(message = "아이디 입력은 필수입니다.")
+  private String userId;
+
+  @NotBlank(message = "비밀번호 입력은 필수입니다.")
+  private String password;
+
+  @NotBlank(message = "닉네임 입력은 필수입니다.")
+  private String nickname;
+
+  @NotBlank(message = "이메일 입력은 필수입니다.")
+  private String email;
+
+  @NotBlank(message = "좋아하는 팀 입력은 필수입니다.")
+  private String favoriteTeam;
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,4 @@ spring.datasource.password=ckddbs79
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 
-#?????? ??
+#name setting
 spring.application.name=KickBoard
 
-# DB ??
+# DB setting
 spring.datasource.url=jdbc:mysql://localhost:3306/kickboard?serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=ckddbs79
@@ -10,3 +10,6 @@ spring.datasource.password=ckddbs79
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+#JWT SECRET KEY ADD
+jwt.secret=mySecretKeymySecretKeymySecretKeymySecretKeymySecretKeymySecretKey1234


### PR DESCRIPTION
변경사항
AS-IS
회원가입 : 오직 회원가입 기능만 구현되어 있었습니다.
로그인 기능  미 구현되어있었음, 인증 및 세션 관리 미 구현,JWT 기반의 인증 및 세션 관리 또한 이루어지지 않고 있었습니다.
예외 처리: 전역적인 예외 처리가 구현되지 않아, 개별 API에서 발생하는 오류에 대한 일관된 응답 처리가 어려웠습니다.

TO-BE
회원 가입: 정상적으로 작동하며, 동일한 ID로 중복 가입을 시도할 경우 적절히 방지되도록 처리되었습니다.
로그인 API 구현:
/members/login 엔드포인트를 통해 로그인 기능을 추가했습니다.
회원가입이 완료된 ID와 Password를 통해 로그인 시 JWT를 발급받을 수 있도록 구현되었습니다.
JWT 시크릿 키 설정 및 키 길이 부족 오류 등의 문제 해결
사용자가 발급받은 JWT 토큰을 이용하여 API 요청 시 인증을 수행하도록 시스템을 구축했습니다.
컨트롤러에 (/members/me) 엔드포인트를 추가하여, JWT 토큰으로부터 사용자 ID를 추출하는 기능을 구현하고 테스트를 완료했습니다. 
# 아직 테스트 코드 나눠놓지 않음
테스트 코드
API 테스트
# postman 통해 회원가입,로그인 API구현 확인 , 컨트롤러에 토큰에서 아이디 추출 기능 위해 (/members/me) 추가 및 테스트 완료
Reviewers
@mingming-mentor